### PR TITLE
#86 Refactor: 이미지 업로드 방식 수정, 기타 리팩토링(회원가입, 후기글 작성 시 내 투표 보기, 후보 등록)

### DIFF
--- a/.platform/nginx/conf.d/client_max_body_size.conf
+++ b/.platform/nginx/conf.d/client_max_body_size.conf
@@ -1,1 +1,1 @@
-# client_max_body_size 200M;
+client_max_body_size 200M;

--- a/src/main/java/friend/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/friend/spring/apiPayload/code/status/ErrorStatus.java
@@ -33,7 +33,8 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_NOT_CORRECT_USER(HttpStatus.BAD_REQUEST, "POST4002", "올바른 사용자(글 작성자)가 아닙니다."),
     POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4003", "글에 대한 좋아요 데이터를 찾을 수 없습니다."),
     POST_SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4004", "글에 대한 스크랩 데이터를 찾을 수 없습니다."),
-    COMMENT_LIKE_DUPLICATE(HttpStatus.BAD_REQUEST, "POST4005", "글에 대한 좋아요 데이터가 이미 존재합니다."),
+    POST_GENERAL_POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4005", "글에 대한 일반 투표 데이터를 찾을 수 없습니다."),
+    POST_CARD_POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4006", "글에 대한 카드 투표 데이터를 찾을 수 없습니다."),
 
     // 댓글 관련 응답
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글을 찾을 수 없습니다."),
@@ -42,6 +43,7 @@ public enum ErrorStatus implements BaseErrorCode {
     COMMENT_SELECT_MYSELF(HttpStatus.BAD_REQUEST, "COMMENT4004", "자기 자신은 채택할 수 없습니다."),
     COMMENT_NOT_CORRECT_USER(HttpStatus.BAD_REQUEST, "COMMENT4005", "올바른 사용자(댓글 작성자)가 아닙니다."),
     COMMENT_POST_NOT_MATCH(HttpStatus.BAD_REQUEST, "COMMENT4006", "해당 글에 작성된 댓글이 아닙니다."),
+    COMMENT_LIKE_DUPLICATE(HttpStatus.BAD_REQUEST, "COMMENT4007", "댓글에 대한 좋아요 데이터가 이미 존재합니다."),
 
     // 알림 관련 응답
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM4001", "알림이 없습니다"),

--- a/src/main/java/friend/spring/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/friend/spring/aws/s3/AmazonS3Manager.java
@@ -55,7 +55,7 @@ public class AmazonS3Manager{
         return amazonConfig.getPostPath() + '/' + uuid.getUuid();
     }
 
-    public String generateReportKeyName(Uuid uuid) {
-        return amazonConfig.getReportPath() + '/' + uuid.getUuid();
+    public String generateCandidateKeyName(Uuid uuid) {
+        return amazonConfig.getCandidatePath() + '/' + uuid.getUuid();
     }
 }

--- a/src/main/java/friend/spring/config/AmazonConfig.java
+++ b/src/main/java/friend/spring/config/AmazonConfig.java
@@ -38,8 +38,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.post}")
     private String postPath;
 
-    @Value("${cloud.aws.s3.path.report}")
-    private String reportPath;
+    @Value("${cloud.aws.s3.path.candidate}")
+    private String candidatePath;
+
 
     @PostConstruct
     public void init() {

--- a/src/main/java/friend/spring/converter/CandidateConverter.java
+++ b/src/main/java/friend/spring/converter/CandidateConverter.java
@@ -12,4 +12,11 @@ public class CandidateConverter {
                 .ratio(percent)
                 .build();
     }
+
+    public static CandidateResponseDTO.AddCandidateResultDTO toAddCandidateResultDTO(Candidate candidate) {
+        return CandidateResponseDTO.AddCandidateResultDTO.builder()
+                .candidateId(candidate.getId())
+                .createdAt(candidate.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/friend/spring/converter/CommentConverter.java
+++ b/src/main/java/friend/spring/converter/CommentConverter.java
@@ -53,12 +53,18 @@ public class CommentConverter {
             }
         }
 
+        // 유저 프로필
+        String userPhoto = null;
+        if (comment.getUser().getFile() != null) {
+            userPhoto = comment.getUser().getFile().getUrl();
+        }
+
         return CommentResponseDTO.commentGetRes.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .userId(comment.getUser().getId())
                 .userNickname(comment.getUser().getNickname())
-                .userImage(comment.getUser().getImage())
+                .userImage(userPhoto)
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .parentCommentId(parentCommentId)

--- a/src/main/java/friend/spring/converter/FileConverter.java
+++ b/src/main/java/friend/spring/converter/FileConverter.java
@@ -1,0 +1,32 @@
+package friend.spring.converter;
+
+import friend.spring.domain.Candidate;
+import friend.spring.domain.File;
+import friend.spring.domain.Post;
+import friend.spring.domain.User;
+import friend.spring.web.dto.FileDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FileConverter {
+
+    public static File toFile(String pictureUrl, User user, Post post, Candidate candidate) {
+        return File.builder()
+                .url(pictureUrl)
+                .user(user)
+                .post(post)
+                .candidate(candidate)
+                .build();
+    }
+
+    public static List<FileDTO> toFileDTO(List<File> fileList) {
+        return fileList.stream()
+                .map(file -> FileDTO.builder()
+                        .imageId(file.getId())
+                        .imageUrl(file.getUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/friend/spring/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/friend/spring/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package friend.spring.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/friend/spring/converter/UserConverter.java
+++ b/src/main/java/friend/spring/converter/UserConverter.java
@@ -21,8 +21,13 @@ public class UserConverter {
 
 
     public static UserResponseDTO.MyPageResDTO toMypageResDTO(User user){
+        String userPhoto = null;
+        if (user.getFile() != null) {
+            userPhoto = user.getFile().getUrl();
+        }
+
         return UserResponseDTO.MyPageResDTO.builder()
-                .userPhoto(user.getImage())
+                .userPhoto(userPhoto)
                 .userName(user.getNickname())
                 .userPoint(user.getPoint())
                 .userLevelInt(user.getLevel().getLike()+1)
@@ -55,7 +60,7 @@ public class UserConverter {
     }
 
 
-    public static User toUser(UserRequestDTO.UserJoinRequest userJoinRequest, String pw){
+    public static User toUser(UserRequestDTO.UserJoinRequest userJoinRequest, String pw, Level initLevel){
 
         Gender gender = null;
 
@@ -82,11 +87,11 @@ public class UserConverter {
                 .agree_marketing(userJoinRequest.isAgree_marketing())
                 .birth(userJoinRequest.getBirth())
                 .kakao(userJoinRequest.getKakao())
-                .image(userJoinRequest.getImage())
                 .is_deleted(userJoinRequest.is_deleted())
                 .point(userJoinRequest.getPoint())
                 .like(userJoinRequest.getLike())
                 .role(RoleType.USER)
+                .level(initLevel)
                 .build();
     }
 
@@ -114,10 +119,16 @@ public class UserConverter {
                 .filter(post -> post.getCommentChoiceList().isEmpty()).collect(Collectors.toList());
         double pChoicePercent = ((double) (Question - myPostList.size()) / (double) Question)*100;
 
+        // 유저 프로필
+        String userPhoto = null;
+        if (user.getFile() != null) {
+            userPhoto = user.getFile().getUrl();
+        }
+
         //남은 다음 등급
         double nxtGrade = ((double)user.getLike()/(double)(nxtLevel.getLike() - user.getLevel().getLike())) * 100.0;
         return UserResponseDTO.QuestionResDTO.builder()
-                .userPhoto(user.getImage())
+                .userPhoto(userPhoto)
                 .nickName(user.getNickname())
                 .recommend(user.getLike())
                 .grade(user.getLevel().getName())
@@ -146,10 +157,16 @@ public class UserConverter {
         //채택 답변률
         double percent = ((double)choice / (double)all) * 100.0;
 
+        // 유저 프로필
+        String userPhoto = null;
+        if (user.getFile() != null) {
+            userPhoto = user.getFile().getUrl();
+        }
+
         //남은 다음 등급
         double nxtGrade = ((double)user.getLike()/(double)(nxtLevel.getLike() - user.getLevel().getLike())) * 100.0;
         return UserResponseDTO.AnswerResDTO.builder()
-                .userPhoto(user.getImage())
+                .userPhoto(userPhoto)
                 .nickName(user.getNickname())
                 .recommend(user.getLike())
                 .grade(user.getLevel().getName())
@@ -162,10 +179,16 @@ public class UserConverter {
     }
 
     public static UserResponseDTO.UserSummaryInfo toUserSummaryInfo(User user) {
+        // 유저 프로필
+        String userPhoto = null;
+        if (user.getFile() != null) {
+            userPhoto = user.getFile().getUrl();
+        }
+
         return UserResponseDTO.UserSummaryInfo.builder()
                 .user_id(user.getId())
                 .nickname(user.getNickname())
-                .image(user.getImage())
+                .image(userPhoto)
                 .build();
     }
 

--- a/src/main/java/friend/spring/domain/Candidate.java
+++ b/src/main/java/friend/spring/domain/Candidate.java
@@ -18,8 +18,6 @@ public class Candidate extends BaseEntity {
 
     private String name;
 
-    private String image;
-
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "generalPoll_id")
     private General_poll generalPoll;
@@ -27,6 +25,10 @@ public class Candidate extends BaseEntity {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "cardPoll_id")
     private Card_poll cardPoll;
+
+    @OneToOne(mappedBy = "candidate")
+    @JoinColumn(name = "file_id")
+    private File file;
 
     public void setGeneralPoll(General_poll generalPoll) {
     this.generalPoll = generalPoll;
@@ -48,5 +50,7 @@ public class Candidate extends BaseEntity {
         }
     }
 
-
+    public void setFile(File file) {
+        this.file = file;
+    }
 }

--- a/src/main/java/friend/spring/domain/File.java
+++ b/src/main/java/friend/spring/domain/File.java
@@ -1,0 +1,32 @@
+package friend.spring.domain;
+
+import friend.spring.domain.common.BaseEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class File extends BaseEntity { // S3에 저장한 이미지 파일 링크들 관리
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "candidate_id")
+    private Candidate candidate;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/friend/spring/domain/Post.java
+++ b/src/main/java/friend/spring/domain/Post.java
@@ -50,8 +50,8 @@ public class Post extends BaseEntity {
     @Column(nullable = true)
     private Integer point;
 
-    @Column(nullable = true)
-    private String file;
+//    @Column(nullable = true)
+//    private String file;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -92,6 +92,9 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post")
     private List<Comment_choice> commentChoiceList = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "post")
+    private List<File> fileList = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cardPoll_id")

--- a/src/main/java/friend/spring/domain/Post.java
+++ b/src/main/java/friend/spring/domain/Post.java
@@ -50,9 +50,6 @@ public class Post extends BaseEntity {
     @Column(nullable = true)
     private Integer point;
 
-//    @Column(nullable = true)
-//    private String file;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/friend/spring/domain/User.java
+++ b/src/main/java/friend/spring/domain/User.java
@@ -58,9 +58,6 @@ public class User extends BaseEntity implements UserDetails {
     @Column(nullable = true)
     private Boolean agree_info;
 
-//    @Column(nullable = true)
-//    private String image;
-
     @Column(nullable = true)//잠시 true로 수정
     private Boolean is_deleted;
 

--- a/src/main/java/friend/spring/domain/User.java
+++ b/src/main/java/friend/spring/domain/User.java
@@ -58,8 +58,8 @@ public class User extends BaseEntity implements UserDetails {
     @Column(nullable = true)
     private Boolean agree_info;
 
-    @Column(nullable = true)
-    private String image;
+//    @Column(nullable = true)
+//    private String image;
 
     @Column(nullable = true)//잠시 true로 수정
     private Boolean is_deleted;
@@ -121,6 +121,10 @@ public class User extends BaseEntity implements UserDetails {
     @Builder.Default
     @OneToMany(mappedBy = "user")
     private List<Gauge_vote> gaugeVoteList = new ArrayList<>();
+
+    @OneToOne(mappedBy = "user")
+    @JoinColumn(name = "file_id")
+    private File file;
 
     // UserDetails 상속
     @Override

--- a/src/main/java/friend/spring/domain/enums/S3ImageType.java
+++ b/src/main/java/friend/spring/domain/enums/S3ImageType.java
@@ -1,0 +1,5 @@
+package friend.spring.domain.enums;
+
+public enum S3ImageType {
+    USER, POST, CANDIDATE
+}

--- a/src/main/java/friend/spring/repository/FileRepository.java
+++ b/src/main/java/friend/spring/repository/FileRepository.java
@@ -1,0 +1,7 @@
+package friend.spring.repository;
+
+import friend.spring.domain.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+}

--- a/src/main/java/friend/spring/service/PostService.java
+++ b/src/main/java/friend/spring/service/PostService.java
@@ -1,13 +1,18 @@
 package friend.spring.service;
 
 
+import friend.spring.domain.Candidate;
 import friend.spring.domain.Post;
 import friend.spring.domain.User;
 import friend.spring.domain.mapping.Post_like;
 import friend.spring.domain.mapping.Post_scrap;
+import friend.spring.web.dto.PollOptionDTO;
 import friend.spring.web.dto.PostRequestDTO;
 import friend.spring.web.dto.PostResponseDTO;
 import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -20,7 +25,11 @@ public interface PostService {
 
     void checkPostLike(Boolean flag);
 
-    Post joinPost(PostRequestDTO.AddPostDTO request, HttpServletRequest request2);
+    Post joinPost(PostRequestDTO.AddPostDTO request, HttpServletRequest request2, List<MultipartFile> file);
+
+//    Candidate createCandidate(Long postId, PollOptionDTO.PollOptionReq request, HttpServletRequest request2);
+
+    Candidate createCandidate(Long postId, String optionString, MultipartFile optionImg, HttpServletRequest request2);
 
     Boolean checkPoint(PostRequestDTO.AddPostDTO request, User user);
 
@@ -46,6 +55,5 @@ public interface PostService {
     Post_scrap createScrapPost(Long postId, HttpServletRequest request);
 
     void deleteScrapPost(Long postId, HttpServletRequest request);
-
 }
 

--- a/src/main/java/friend/spring/service/PostService.java
+++ b/src/main/java/friend/spring/service/PostService.java
@@ -27,8 +27,6 @@ public interface PostService {
 
     Post joinPost(PostRequestDTO.AddPostDTO request, HttpServletRequest request2, List<MultipartFile> file);
 
-//    Candidate createCandidate(Long postId, PollOptionDTO.PollOptionReq request, HttpServletRequest request2);
-
     Candidate createCandidate(Long postId, String optionString, MultipartFile optionImg, HttpServletRequest request2);
 
     Boolean checkPoint(PostRequestDTO.AddPostDTO request, User user);

--- a/src/main/java/friend/spring/service/PostServiceImpl.java
+++ b/src/main/java/friend/spring/service/PostServiceImpl.java
@@ -95,33 +95,22 @@ public class PostServiceImpl implements PostService{
     @Override
     @Transactional
     public Post joinPost(PostRequestDTO.AddPostDTO request, HttpServletRequest request2, List<MultipartFile> file) {
-        System.out.println("테스트0");
-
         Long userId = jwtTokenProvider.getCurrentUser(request2);
 
-        System.out.println("테스트0.5");
-
         Post newPost= PostConverter.toPost(request);
-        System.out.println("테스트0.7");
         User user=userRepository.findById(userId)
                 .orElseThrow(()->new RuntimeException("\""+userId+"\"해당 유저가 없습니다"));
-        System.out.println("테스트0.9");
         newPost.setUser(user);
-
-        System.out.println("테스트1");
 
         // 글 첨부파일 사진 저장
         s3Service.uploadPostImages(file, S3ImageType.POST, newPost);
-
-        System.out.println("테스트2");
 
         //일반 투표 api
         if(newPost.getPostType()==VOTE){
             newPost.setCategory(categoryRepository.findByName(request.getCategory()));
 
         }
-        System.out.println("테스트3");
-//        if(newPost.getPostType()==VOTE&&newPost.getVoteType()==GENERAL&&pollOption!=null){
+
         if(newPost.getPostType()==VOTE&&newPost.getVoteType()==GENERAL){
             //포인트 차감 관련 코드
             if(request.getPoint()!=null) {
@@ -136,7 +125,6 @@ public class PostServiceImpl implements PostService{
                 newPoint.setUser(user);
                 pointRepository.save(newPoint);
             }
-            System.out.println("테스트4");
 
             General_poll generalPoll = General_poll.builder()
                     .pollTitle(request.getPollTitle())
@@ -146,26 +134,10 @@ public class PostServiceImpl implements PostService{
                 generalPoll.setMultipleChoice(request.getMultipleChoice());
             }
             newPost.setGeneralPoll(generalPoll);
-            System.out.println("테스트5");
             generalPollRepository.save(generalPoll);
 
-            System.out.println("테스트6");
-
-//            for (PollOptionDTO.PollOptionReq option : pollOption) {
-//                Candidate candidate = Candidate.builder()
-//                        .name(option.getOptionString())
-//                        .build();
-//
-//                File candidateFile = s3Service.uploadSingleImage(option.getOptionImg(), S3ImageType.CANDIDATE, null, candidate);
-//                candidate.setFile(candidateFile);
-//
-//                candidate.setGeneralPoll(generalPoll);
-//                candidateRepository.save(candidate);
-//            }
-            System.out.println("테스트7");
         }
 //카드 투표 api
-//        if(newPost.getPostType()==VOTE&&newPost.getVoteType()==CARD&&pollOption!=null){
         if(newPost.getPostType()==VOTE&&newPost.getVoteType()==CARD){
             //포인트 차감 관련 코드
             if(request.getPoint()!=null) {
@@ -180,7 +152,6 @@ public class PostServiceImpl implements PostService{
                 newPoint.setUser(user);
                 pointRepository.save(newPoint);
             }
-            System.out.println("테스트8");
 
             if(!checkPoint(request, user)&&request.getPoint()!=null){
                 throw new RuntimeException("\""+userId+"\"해당 유저의 포인트가 부족 합니다");
@@ -195,20 +166,6 @@ public class PostServiceImpl implements PostService{
             }
             newPost.setCardPoll(cardPoll);
             cardPollRepository.save(cardPoll);
-            System.out.println("테스트9");
-
-//            for (PollOptionDTO.PollOptionReq option : pollOption) {
-//                Candidate candidate = Candidate.builder()
-//                        .name(option.getOptionString())
-//                        .build();
-//
-//                File candidateFile = s3Service.uploadSingleImage(option.getOptionImg(), S3ImageType.CANDIDATE, null, candidate);
-//                candidate.setFile(candidateFile);
-//
-//                candidate.setCardPoll(cardPoll);
-//                candidateRepository.save(candidate);
-//            }
-            System.out.println("테스트10");
         }
 //게이지 투표 api
         if(newPost.getPostType()==VOTE&&newPost.getVoteType()==GAUGE){
@@ -249,41 +206,9 @@ public class PostServiceImpl implements PostService{
             newPost.setParentPost(parent);
         }
 
-        System.out.println("테스트11");
         return postRepository.save(newPost);
 
     }
-
-//    @Override
-//    public Candidate createCandidate(Long postId, PollOptionDTO.PollOptionReq request, HttpServletRequest request2) {
-//        Post newPost = postRepository.findById(postId).orElseThrow(() -> new GeneralException(POST_NOT_FOUND));
-//
-//        Long userId = jwtTokenProvider.getCurrentUser(request2);
-//        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
-//        if (!newPost.getUser().equals(user)) { // 이 글을 쓴 사용자인지 검증
-//            this.checkPostWriterUser(false);
-//        }
-//
-//        Candidate candidate = Candidate.builder()
-//                .name(request.getOptionString())
-//                .build();
-//
-//        File candidateFile = s3Service.uploadSingleImage(request.getOptionImg(), S3ImageType.CANDIDATE, null, candidate);
-//        candidate.setFile(candidateFile);
-//
-//        // 일반 투표
-//        if(newPost.getPostType()==VOTE&&newPost.getVoteType()==GENERAL) {
-//            General_poll generalPoll = generalPollRepository.findById(newPost.getGeneralPoll().getId()).orElseThrow(() -> new GeneralException(POST_GENERAL_POLL_NOT_FOUND));
-//            candidate.setGeneralPoll(generalPoll);
-//        }
-//        // 카드 투표
-//        else {
-//            Card_poll cardPoll = cardPollRepository.findById(newPost.getCardPoll().getId()).orElseThrow(() -> new GeneralException(POST_CARD_POLL_NOT_FOUND));
-//            candidate.setCardPoll(cardPoll);
-//        }
-//
-//        return candidateRepository.save(candidate);
-//    }
 
     @Override
     @Transactional

--- a/src/main/java/friend/spring/service/S3Service.java
+++ b/src/main/java/friend/spring/service/S3Service.java
@@ -1,13 +1,18 @@
 package friend.spring.service;
 
 import friend.spring.aws.s3.AmazonS3Manager;
-import friend.spring.domain.Uuid;
+import friend.spring.converter.FileConverter;
+import friend.spring.domain.*;
+import friend.spring.domain.enums.S3ImageType;
+import friend.spring.repository.FileRepository;
 import friend.spring.repository.UuidRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -17,13 +22,36 @@ public class S3Service {
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager s3Manager;
 
-    // 유저 프로필 사진 올리기인 경우
-    public String uploadUserImage(MultipartFile file) {
-        String uuid = UUID.randomUUID().toString();
-        Uuid savedUuid = uuidRepository.save(Uuid.builder()
-                .uuid(uuid).build());
+    private final FileRepository fileRepository;
 
-        String pictureUrl = s3Manager.uploadFile(s3Manager.generateUserKeyName(savedUuid), file);
-        return pictureUrl;
+    public List<File> uploadPostImages(List<MultipartFile> multipartFiles, S3ImageType type, Post post) {
+        List<File> fileList = new ArrayList<>();
+        // forEach 구문을 통해 multipartFiles 리스트로 넘어온 파일들을 순차적으로 fileNameList 에 추가
+        multipartFiles.forEach(file -> {
+            String pictureUrl = s3Manager.uploadFile(s3Manager.generatePostKeyName(createFileName()), file);
+            File newFile = fileRepository.save(FileConverter.toFile(pictureUrl, null, post, null));
+            fileList.add(newFile);
+        });
+        return fileList;
+    }
+
+    public File uploadSingleImage(MultipartFile file, S3ImageType type, User user, Candidate candidate) {
+        File newFile;
+        if (type == S3ImageType.USER && user != null) { // 사용자 프로필 이미지인 경우
+            String pictureUrl = s3Manager.uploadFile(s3Manager.generateUserKeyName(createFileName()), file);
+            newFile = fileRepository.save(FileConverter.toFile(pictureUrl, user, null, null));
+
+        } else { // 후보 이미지인 경우
+            String pictureUrl = s3Manager.uploadFile(s3Manager.generateCandidateKeyName(createFileName()), file);
+            newFile = fileRepository.save(FileConverter.toFile(pictureUrl, null, null, candidate));
+        }
+        return newFile;
+    }
+
+
+    // 먼저 파일 업로드시, 파일명을 난수화하기 위해 UUID 를 활용하여 난수를 돌린다.
+    public Uuid createFileName() {
+        String uuid = UUID.randomUUID().toString();
+        return uuidRepository.save(Uuid.builder().uuid(uuid).build());
     }
 }

--- a/src/main/java/friend/spring/service/UserServiceImpl.java
+++ b/src/main/java/friend/spring/service/UserServiceImpl.java
@@ -67,7 +67,8 @@ public class UserServiceImpl implements UserService {
 
         String encodedPw = encoder.encode(userJoinRequest.getPassword());
 
-        User newUser = UserConverter.toUser(userJoinRequest, encodedPw);
+        Level initLevel = levelRepository.findById(Long.valueOf(1)).get();
+        User newUser = UserConverter.toUser(userJoinRequest, encodedPw, initLevel);
 
         return userRepository.saveAndFlush(newUser);
     }

--- a/src/main/java/friend/spring/web/controller/PostRestController.java
+++ b/src/main/java/friend/spring/web/controller/PostRestController.java
@@ -38,7 +38,6 @@ public class PostRestController {
     private final PostQueryService postQueryService;
     private final PostRepository postRepository;
     private final JwtTokenService jwtTokenService;
-//    @PostMapping(value = "/", consumes = "multipart/form-data")
     @PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "글 작성 API", description = "글을 추가 합니다.")
     @Parameters({
@@ -50,7 +49,6 @@ public class PostRestController {
             @Parameter(name="postVoteType", description="<Integer> 투표 종류<br>1 : GENERAL <br>2 : GAUGE <br>3 : CARD<br>해당 사항 없을시 null"),
             @Parameter(name="pollTitle", description="<String> 투표 제목"),
             @Parameter(name="multipleChoice", description="<Boolean> 복수 선택 여부"),
-//            @Parameter(name="pollOption", description="<Class> 투표 후보{optionString : string, optionImg : string}<br>해당 사항 없을시 null"),
             @Parameter(name="parent_id", description="<Long> 원글(후기글 경우) id<br>해당 사항 없을시 null"),
             @Parameter(name="deadline", description="<Timestamp> 투표 마감 시간<br>해당 사항 없을시 null"),
             @Parameter(name="point", description="<Integer> 포인트<br>해당 사항 없을시 null")
@@ -58,10 +56,8 @@ public class PostRestController {
     })
     public ApiResponse<PostResponseDTO.AddPostResultDTO> join(@RequestPart(value = "request") @Valid PostRequestDTO.AddPostDTO request,
                                                               @RequestPart(value = "file", required = false) List<MultipartFile> file,
-//                                                              @RequestPart(value = "pollOptionImages", required = false) List<MultipartFile> pollOptionFiles,
                                                               @RequestHeader("atk") String atk,
                                                               HttpServletRequest request2){
-        System.out.println("테스트000000");
         Post post= postService.joinPost(request,request2, file);
         return ApiResponse.onSuccess(PostConverter.toAddPostResultDTO(post));
     }
@@ -74,12 +70,10 @@ public class PostRestController {
     })
     public ApiResponse<CandidateResponseDTO.AddCandidateResultDTO> createCandidate(
             @PathVariable(name="post-id") Long postId,
-//            @RequestBody PollOptionDTO.PollOptionReq request,
             @RequestParam String optionString,
             @RequestParam(required = false) MultipartFile optionImg,
             @RequestHeader("atk") String atk,
             HttpServletRequest request2) {
-//        Candidate candidate = postService.createCandidate(postId, request,request2);
         Candidate candidate = postService.createCandidate(postId, optionString, optionImg,request2);
         return ApiResponse.onSuccess(CandidateConverter.toAddCandidateResultDTO(candidate));
     }

--- a/src/main/java/friend/spring/web/controller/S3Controller.java
+++ b/src/main/java/friend/spring/web/controller/S3Controller.java
@@ -1,21 +1,24 @@
 package friend.spring.web.controller;
 
 import friend.spring.apiPayload.ApiResponse;
+import friend.spring.domain.enums.S3ImageType;
 import friend.spring.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/uploadImage")
+@RequestMapping("/file")
 public class S3Controller {
     private final S3Service s3Service;
 
-    // 유저 이미지 올리기
-    @PostMapping(value = "", consumes = "multipart/form-data")
-    public ApiResponse uploadUserImage(@RequestParam("file") MultipartFile file) {
-        String url = s3Service.uploadUserImage(file);
-        return ApiResponse.onSuccess(url);
-    }
+    // 유저 프로필 이미지 올리기
+//    @PostMapping(value = "/uploadImage", consumes = "multipart/form-data")
+//    public ApiResponse<List<String>> uploadUserImage(@RequestParam("file") List<MultipartFile> file) {
+//        List<String> url = s3Service.uploadImage(file, S3ImageType.USER);
+//        return ApiResponse.onSuccess(url);
+//    }
 }

--- a/src/main/java/friend/spring/web/dto/CandidateResponseDTO.java
+++ b/src/main/java/friend/spring/web/dto/CandidateResponseDTO.java
@@ -1,9 +1,8 @@
 package friend.spring.web.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 public class CandidateResponseDTO {
     @Builder
@@ -14,5 +13,14 @@ public class CandidateResponseDTO {
         Long candidate_id; // 후보 아이디
         String candidate_name; // 후보 이름
         Double ratio; // 비율
+    }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddCandidateResultDTO {
+        Long candidateId;
+        LocalDateTime createdAt;
     }
 }

--- a/src/main/java/friend/spring/web/dto/FileDTO.java
+++ b/src/main/java/friend/spring/web/dto/FileDTO.java
@@ -1,0 +1,13 @@
+package friend.spring.web.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileDTO {
+    private Long imageId;
+    private String imageUrl;
+}

--- a/src/main/java/friend/spring/web/dto/ParentPostDTO.java
+++ b/src/main/java/friend/spring/web/dto/ParentPostDTO.java
@@ -14,7 +14,7 @@ public class ParentPostDTO {
     String nickname;
     String title;
     String content;
-    List<PollOptionDTO> pollOption;
+    List<PollOptionDTO.PollOptionRes> pollOption;
     ParentPollDTO pollContent;
     Integer gauge;
     Integer like;
@@ -25,6 +25,7 @@ public class ParentPostDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CandidatePostDTO {
+        Long postId;
         String title;
         String content;
         Integer like;

--- a/src/main/java/friend/spring/web/dto/PollOptionDTO.java
+++ b/src/main/java/friend/spring/web/dto/PollOptionDTO.java
@@ -1,13 +1,29 @@
 package friend.spring.web.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
-@Getter
-@Builder
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class PollOptionDTO {
-    private String optionString;
-    private String optionImg;
+
+    @Getter
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PollOptionReq {
+        private String optionString;
+        private MultipartFile optionImg;
+    }
+
+    @Getter
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PollOptionRes {
+        private String optionString;
+        private String optionImgUrl;
+    }
 }

--- a/src/main/java/friend/spring/web/dto/PostRequestDTO.java
+++ b/src/main/java/friend/spring/web/dto/PostRequestDTO.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.tomcat.jni.Poll;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import java.sql.Timestamp;
@@ -26,12 +27,12 @@ public class PostRequestDTO {
         Integer postVoteType;// 1: general, 2: gauge
         String pollTitle;
         Boolean multipleChoice;
-        List<PollOptionDTO> pollOption;
+//        List<PollOptionDTO.PollOptionReq> pollOption;
         Long parent_id;
         @NotBlank
         Timestamp deadline;
         Integer point;
-        String file;
+//        List<MultipartFile> file;
     }
     @Getter
     public static class ReviewPostGetDTO{

--- a/src/main/java/friend/spring/web/dto/PostRequestDTO.java
+++ b/src/main/java/friend/spring/web/dto/PostRequestDTO.java
@@ -27,12 +27,10 @@ public class PostRequestDTO {
         Integer postVoteType;// 1: general, 2: gauge
         String pollTitle;
         Boolean multipleChoice;
-//        List<PollOptionDTO.PollOptionReq> pollOption;
         Long parent_id;
         @NotBlank
         Timestamp deadline;
         Integer point;
-//        List<MultipartFile> file;
     }
     @Getter
     public static class ReviewPostGetDTO{

--- a/src/main/java/friend/spring/web/dto/PostResponseDTO.java
+++ b/src/main/java/friend/spring/web/dto/PostResponseDTO.java
@@ -1,12 +1,10 @@
 package friend.spring.web.dto;
-import friend.spring.domain.Candidate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.*;
 
-import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,14 +28,14 @@ public class PostResponseDTO {
         LocalDateTime createdAt;
         String title;
         String content;
-        String file;
+        List<FileDTO> file; // 첨부파일 이미지 리스트
         String pollTitle; // 투표글에서만 사용, 후기글에서는 null
-        List<PollOptionDTO> pollOption; // 투표글에서만 사용, 후기글에서는 null
+        List<PollOptionDTO.PollOptionRes> pollOption; // 투표글에서만 사용, 후기글에서는 null
         Integer gauge; // 게이지 투표글에서만 사용, 후기글에서는 null
         Integer point; // 투표글에서만 사용, 후기글에서는 null
         ParentPostDTO parentPost; // 후기글에서만 사용, 일반글에서는 null
         Timestamp deadline; // 투표글에서만 사용, 후기글에서는 null
-        List<PollOptionDTO> userVote; // 투표글에서 사용자가 투표완료시 투표한 후보
+        List<PollOptionDTO.PollOptionRes> userVote; // 투표글에서 사용자가 투표완료시 투표한 후보
         List<Integer> percent; // 투표글에서 사용자가 투표 완료시 투표한 후보 선택 퍼센트
         List<String> voteResult; // 투표글에서 사용자가 투표 완료시 투표인원/총인원
         Integer view;
@@ -66,8 +64,8 @@ public class PostResponseDTO {
         String title;
         String content;
         LocalDateTime uploadDate;
-        List<PollOptionDTO> pollOption;
-        List<PollOptionDTO> userVote;
+        List<PollOptionDTO.PollOptionRes> pollOption;
+        List<PollOptionDTO.PollOptionRes> userVote;
         Integer gauge;
         Integer like;
         Integer comment;
@@ -92,7 +90,7 @@ public class PostResponseDTO {
         String title;
         String content;
         LocalDateTime uploadDate;
-        String ReviewPic;
+        List<FileDTO> ReviewPicList;
         Integer like;
         Integer comment;
         Boolean isLike;
@@ -127,7 +125,7 @@ public class PostResponseDTO {
         String title;
         String content;
         Long post_id;
-        String file;
+        List<FileDTO> file;
         Integer like;
         Integer comment_cnt;
         LocalDateTime created_at;

--- a/src/main/java/friend/spring/web/dto/UserRequestDTO.java
+++ b/src/main/java/friend/spring/web/dto/UserRequestDTO.java
@@ -29,7 +29,6 @@ public class UserRequestDTO {
         boolean agree_marketing;
         LocalDate birth;
         boolean is_deleted;
-        String image;
         Integer point;
         String kakao;
         Integer like;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 200MB
+      max-request-size: 200MB
   redis:
     host: ${REDIS_HOSTNAME}
     port: ${REDIS_PORT}
@@ -30,7 +34,7 @@ cloud:
       path:
         user: users
         post: posts
-        report: reports
+        candidate: candidates
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
### 변경된 사항
- 회원가입 시 프로필 이미지를 받지 않기 때문에 `UserRequestDTO.UserJoinRequest`에 있었던 `String image`는 삭제했습니다!
- 회원가입 시 level을 1로 강제로 설정하였습니다!
- 후기글 작성시 내투표 보기 API에서, 글 id도 같이 보내주도록 변경했습니다!
- 🔥이미지 테이블을 따로 분리했습니다. 이제 User, Post, Candidate 테이블에서는 이미지를 담지 않습니다!
- 🔥글 작성 시 글과 poll (general_poll, gauge_poll, card_poll) 은 먼저 생성되는데, 후보들은 따로 생성하도록 API를 분리했습니다! 
   [이유]
   - 후보들에서도 이미지 파일을 받아와야 하는데 그냥 글 첨부 이미지 추가하는 것과는 조금 달라서 한 API 안에서 작업하기가 쉽지 않더라구요.. (제 실력 문제일수도,,😂) 
   - 어떤 후보는 사진 추가하고 어떤 후보는 사진 안 추가하고 이래야 하니까,, 이 정보를 한 API에서 `List<MultipartFile>` 로 받아오기에는 한계가 있다고 판단했습니다.. 그래서 부득이 하게 다른 API로 분리했습니다..!!

현재 AWS RDS DB 내용을 export 해와서 로컬 DB에서 똑같은 환경 만들어두고, 
작성/조회 등등 관련 API 테스트해보면서 보완 완료했습니다!