### PR TITLE
#155 Refactor: nginx.conf에서 cors 설정 제거 (테스트)

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -36,10 +36,13 @@ http {
 
       location / {
           proxy_pass          http://springboot;
+          proxy_connect_timeout 3600;
+          proxy_send_timeout    3600;
+          proxy_read_timeout    3600;
                   # CORS 관련 헤더 추가
-          add_header 'Access-Control-Allow-Origin' '*';
-          add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-          add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type';
+#           add_header 'Access-Control-Allow-Origin' '*';
+#           add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+#           add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type';
           proxy_http_version  1.1;
           proxy_set_header    Connection          $connection_upgrade;
           proxy_set_header    Upgrade             $http_upgrade;


### PR DESCRIPTION
여러 설정을 변경해보았지만,, 프론트쪽에서 연동할 때 계속 cors 에러가 떠서,,
nginx나 스프링 둘 중 하나의 설정을 제거해보라는 글이 있길래,, nginx에서 설정 한번 지워보고 다시 해보겠습니다..!!

https://minholee93.tistory.com/entry/ERROR-The-Access-Control-Allow-Origin-header-contains-multiple-values